### PR TITLE
Potential fix for code scanning alert no. 33: Bad HTML filtering regexp

### DIFF
--- a/artifacts/novel-reader/hooks/useDirectScraper.ts
+++ b/artifacts/novel-reader/hooks/useDirectScraper.ts
@@ -1891,9 +1891,9 @@ export const directFetchChapter = async (
 
       if (contentHtml) {
         contentHtml = contentHtml
-          .replace(/<script[\s\S]*?<\/script>/gi, "")
-          .replace(/<style[\s\S]*?<\/style>/gi, "")
-          .replace(/<nav[\s\S]*?<\/nav>/gi, "");
+          .replace(/<script\b[^>]*>[\s\S]*?<\/script\b[^>]*>/gi, "")
+          .replace(/<style\b[^>]*>[\s\S]*?<\/style\b[^>]*>/gi, "")
+          .replace(/<nav\b[^>]*>[\s\S]*?<\/nav\b[^>]*>/gi, "");
 
         // No need to specifically strip ad <div> wrappers here — they contain
         // no <p> tags (just <script>/<ins>), so the <p>-only extraction below


### PR DESCRIPTION
Potential fix for [https://github.com/Moggle-Khraum/NovelDR/security/code-scanning/33](https://github.com/Moggle-Khraum/NovelDR/security/code-scanning/33)

Best general fix: avoid custom regex-based HTML sanitization and use a robust HTML sanitizer/parser.  
Best minimal fix within the shown snippet: make the script/style/nav closing-tag regexes tolerant of browser-accepted malformed end tags by allowing optional whitespace/attributes before `>`.

In `artifacts/novel-reader/hooks/useDirectScraper.ts`, update lines 1894–1896 so end-tag patterns become `</tag\b[^>]*>` instead of `</tag>`. This directly addresses CodeQL’s concern (`</script >`) and similar parser-tolerated variants without changing overall behavior.

No new imports or helper methods are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
