### PR TITLE
Potential fix for code scanning alert no. 50: Incomplete URL scheme check

### DIFF
--- a/artifacts/novel-reader/hooks/scrapers/sources/novgo.ts
+++ b/artifacts/novel-reader/hooks/scrapers/sources/novgo.ts
@@ -194,11 +194,14 @@ export const novgoScraper: SourceScraper = {
           attrs.includes("next_chapter")) &&
         href
       ) {
+        const normalizedHref = href ? href.trim().toLowerCase() : "";
         const isPlaceholder =
           !href ||
           href === "#" ||
-          href.startsWith("javascript:") ||
-          href.trim() === "";
+          normalizedHref.startsWith("javascript:") ||
+          normalizedHref.startsWith("data:") ||
+          normalizedHref.startsWith("vbscript:") ||
+          normalizedHref === "";
         const resolved = isPlaceholder ? null : makeAbsoluteUrl(href, url);
         const isSelfReference =
           resolved !== null &&


### PR DESCRIPTION
Potential fix for [https://github.com/Moggle-Khraum/NovelDR/security/code-scanning/50](https://github.com/Moggle-Khraum/NovelDR/security/code-scanning/50)

General fix: when rejecting unsafe placeholder schemes, include `data:` and `vbscript:` alongside `javascript:` after normalizing the candidate URL (trim + lowercase) so case/whitespace variants are also covered.

Best minimal fix in this file: in `artifacts/novel-reader/hooks/scrapers/sources/novgo.ts`, update the `isPlaceholder` logic around lines 197–201 to compute a normalized `href` string and reject if it starts with any of `javascript:`, `data:`, or `vbscript:`. This keeps existing behavior while closing the gap CodeQL reported.

No new imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
