### PR TITLE
Potential fix for code scanning alert no. 60: Incomplete multi-character sanitization

### DIFF
--- a/artifacts/novel-reader/hooks/useDirectScraper.ts
+++ b/artifacts/novel-reader/hooks/useDirectScraper.ts
@@ -335,8 +335,12 @@ const lnwExtractInnerHtml = (html: string): string | null => {
   };
 
   inner = removeNestedDivByClass(inner, "chapter-ad-container");
-  inner = inner.replace(/<style[^>]*>[\s\S]*?<\/style>/gi, "");
-  inner = inner.replace(/<script[^>]*>[\s\S]*?<\/script>/gi, "");
+  let previous: string;
+  do {
+    previous = inner;
+    inner = inner.replace(/<style[^>]*>[\s\S]*?<\/style>/gi, "");
+    inner = inner.replace(/<script[^>]*>[\s\S]*?<\/script>/gi, "");
+  } while (inner !== previous);
   return inner;
 };
 


### PR DESCRIPTION
Potential fix for [https://github.com/Moggle-Khraum/NovelDR/security/code-scanning/60](https://github.com/Moggle-Khraum/NovelDR/security/code-scanning/60)

General fix: avoid single-pass removal of multi-character dangerous patterns. Either use a trusted HTML sanitizer library, or repeatedly apply replacements until the string stabilizes.

Best fix here without changing overall behavior: keep current cleanup approach, but make `<style>`/`<script>` stripping iterative (fixed-point loop). This directly addresses CodeQL’s concern while preserving existing extraction behavior and not introducing new dependencies.

Change needed in `artifacts/novel-reader/hooks/useDirectScraper.ts` around lines 338–340:
- Replace the two one-shot `replace` calls with a loop that repeatedly removes style/script blocks until no further change occurs.
- No new imports, methods, or dependencies required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
