### PR TITLE
Potential fix for code scanning alert no. 56: Incomplete URL substring sanitization

### DIFF
--- a/artifacts/novel-reader/hooks/scrapers/sources/readnovelfull.ts
+++ b/artifacts/novel-reader/hooks/scrapers/sources/readnovelfull.ts
@@ -52,7 +52,9 @@ export const readNovelFullScraper: SourceScraper = {
   name: "ReadNovelFull",
   canHandle: (url: string) => {
     try {
-      return new URL(url).hostname.includes(BASE_HOST);
+      const hostname = new URL(url).hostname.toLowerCase();
+      const baseHost = BASE_HOST.toLowerCase();
+      return hostname === baseHost || hostname.endsWith(`.${baseHost}`);
     } catch {
       return false;
     }


### PR DESCRIPTION
Potential fix for [https://github.com/Moggle-Khraum/NovelDR/security/code-scanning/56](https://github.com/Moggle-Khraum/NovelDR/security/code-scanning/56)

Use structured hostname validation with boundary-aware matching instead of substring matching.

Best fix in this file: in `canHandle` (lines 53–59), parse the URL once, normalize hostname to lowercase, and accept only:
- exact `readnovelfull.com`, or
- subdomains ending with `.readnovelfull.com`.

This preserves intended functionality (handling the base domain and its subdomains) while rejecting lookalikes (`evilreadnovelfull.com`, `readnovelfull.com.evil.org`).

No new imports or dependencies are required; use built-in `URL` and string checks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
