### PR TITLE
Potential fix for code scanning alert no. 58: Incomplete URL substring sanitization

### DIFF
--- a/artifacts/novel-reader/hooks/scrapers/sources/novgo.ts
+++ b/artifacts/novel-reader/hooks/scrapers/sources/novgo.ts
@@ -51,7 +51,8 @@ export const novgoScraper: SourceScraper = {
   name: "NovGo",
   canHandle: (url: string) => {
     try {
-      return new URL(url).hostname.includes(BASE_HOST);
+      const hostname = new URL(url).hostname.toLowerCase();
+      return hostname === BASE_HOST || hostname.endsWith(`.${BASE_HOST}`);
     } catch {
       return false;
     }


### PR DESCRIPTION
Potential fix for [https://github.com/Moggle-Khraum/NovelDR/security/code-scanning/58](https://github.com/Moggle-Khraum/NovelDR/security/code-scanning/58)

Use strict host validation on the parsed hostname instead of substring matching. The best fix here is to allow only the exact base host (`novgo.net`) and legitimate subdomains (`*.novgo.net`) using boundary-aware checks.

In `artifacts/novel-reader/hooks/scrapers/sources/novgo.ts`, update the `canHandle` function (around line 54) to:
1. Parse `hostname` once.
2. Normalize to lowercase.
3. Return `true` only if `hostname === BASE_HOST` or `hostname.endsWith(\`.${BASE_HOST}\`)`.

This preserves intended functionality (accept NovGo domain and its subdomains) while preventing lookalike/concatenated domains from passing.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
