### PR TITLE
Potential fix for code scanning alert no. 53: Incomplete URL substring sanitization

### DIFF
--- a/artifacts/novel-reader/hooks/scrapers/sources/allnovel.ts
+++ b/artifacts/novel-reader/hooks/scrapers/sources/allnovel.ts
@@ -51,7 +51,8 @@ export const allNovelScraper: SourceScraper = {
   name: "AllNovel",
   canHandle: (url: string) => {
     try {
-      return new URL(url).hostname.includes(BASE_HOST);
+      const hostname = new URL(url).hostname.toLowerCase();
+      return hostname === BASE_HOST || hostname.endsWith(`.${BASE_HOST}`);
     } catch {
       return false;
     }


### PR DESCRIPTION
Potential fix for [https://github.com/Moggle-Khraum/NovelDR/security/code-scanning/53](https://github.com/Moggle-Khraum/NovelDR/security/code-scanning/53)

Use strict hostname validation instead of substring matching.

Best fix in this file:
- In `artifacts/novel-reader/hooks/scrapers/sources/allnovel.ts`, update `canHandle` so it:
  - Parses hostname once,
  - Normalizes to lowercase,
  - Returns `true` only when hostname is exactly `allnovel.org` or a subdomain ending with `.allnovel.org`.

This preserves intended functionality (supporting base domain and subdomains) while preventing accidental matches like `evilallnovel.org`.

No new imports or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
