### PR TITLE
Potential fix for code scanning alert no. 63: Incomplete multi-character sanitization

### DIFF
--- a/artifacts/novel-reader/hooks/useDirectScraper.ts
+++ b/artifacts/novel-reader/hooks/useDirectScraper.ts
@@ -1,6 +1,7 @@
 // artifacts/novel-reader/hooks/useDirectScraper.ts
 import axios from "axios";
 import { decodeHTML } from "entities";
+import sanitizeHtml from "sanitize-html";
 
 export interface NovelMeta {
   title: string;
@@ -335,12 +336,10 @@ const lnwExtractInnerHtml = (html: string): string | null => {
   };
 
   inner = removeNestedDivByClass(inner, "chapter-ad-container");
-  let previous: string;
-  do {
-    previous = inner;
-    inner = inner.replace(/<style[^>]*>[\s\S]*?<\/style>/gi, "");
-    inner = inner.replace(/<script[^>]*>[\s\S]*?<\/script>/gi, "");
-  } while (inner !== previous);
+  inner = sanitizeHtml(inner, {
+    allowedTags: [],
+    allowedAttributes: {},
+  });
   return inner;
 };
 


### PR DESCRIPTION
Potential fix for [https://github.com/Moggle-Khraum/NovelDR/security/code-scanning/63](https://github.com/Moggle-Khraum/NovelDR/security/code-scanning/63)

General fix: replace fragile regex-based removal of dangerous HTML elements with a well-tested HTML sanitizer library that removes disallowed tags reliably in one pass.

Best fix in this file: in `artifacts/novel-reader/hooks/useDirectScraper.ts`, replace the `do...while` block that repeatedly strips `<style>`/`<script>` with a call to `sanitize-html`, configured to allow no tags and no attributes for this extracted chapter fragment (equivalent to stripping all markup, including style/script). This avoids incomplete multi-character sanitization patterns entirely and preserves intended behavior of removing unsafe embedded markup.

Needed changes:
- Add `sanitize-html` import at the top of the file.
- Replace lines around the current regex loop (339–343) with one sanitizer call.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
