### PR TITLE
Potential fix for code scanning alert no. 43: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci-cd-pipeline.yml
+++ b/.github/workflows/ci-cd-pipeline.yml
@@ -22,6 +22,9 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   sync-lockfile:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Moggle-Khraum/NovelDR/security/code-scanning/43](https://github.com/Moggle-Khraum/NovelDR/security/code-scanning/43)

Add an explicit workflow-level `permissions` block to define least-privilege defaults for all jobs that do not override permissions. The best low-risk fix is to set:

- `permissions:`
  - `contents: read`

at the root level (after `concurrency` and before `jobs`, or anywhere at workflow root). This preserves existing behavior for read-only jobs and still allows the `format` job to keep its own stricter override (`contents: write`) because job-level permissions override workflow-level defaults. No imports, methods, or dependencies are needed since this is YAML configuration only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
