### PR TITLE
Potential fix for code scanning alert no. 55: Incomplete URL substring sanitization

### DIFF
--- a/artifacts/novel-reader/hooks/scrapers/sources/novelfullnet.ts
+++ b/artifacts/novel-reader/hooks/scrapers/sources/novelfullnet.ts
@@ -53,8 +53,12 @@ export const novelFullNetScraper: SourceScraper = {
   name: "NovelFull.net",
   canHandle: (url: string) => {
     try {
-      const host = new URL(url).hostname;
-      return host.includes(BASE_HOST) && !host.includes("readnovelfull");
+      const host = new URL(url).hostname.toLowerCase();
+      const isNovelFullHost =
+        host === BASE_HOST || host.endsWith(`.${BASE_HOST}`);
+      const isReadNovelFullHost =
+        host === "readnovelfull" || host.includes("readnovelfull.");
+      return isNovelFullHost && !isReadNovelFullHost;
     } catch {
       return false;
     }


### PR DESCRIPTION
Potential fix for [https://github.com/Moggle-Khraum/NovelDR/security/code-scanning/55](https://github.com/Moggle-Khraum/NovelDR/security/code-scanning/55)

Use strict hostname validation instead of substring matching.

Best fix (without changing intended functionality): in `canHandle`, normalize the parsed hostname to lowercase and accept only:
- exact `novelfull.net`, or
- subdomains ending in `.novelfull.net`

Then apply the `readnovelfull` exclusion to label boundaries (exact `readnovelfull` or containing `readnovelfull.`) to preserve existing intent while avoiding loose matching.

### File/region to change
- `artifacts/novel-reader/hooks/scrapers/sources/novelfullnet.ts`
- Inside `canHandle` (around lines 54–58), replace the current `includes` logic.

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
