### PR TITLE
Potential fix for code scanning alert no. 59: Incomplete URL substring sanitization

### DIFF
--- a/artifacts/novel-reader/hooks/useDirectScraper.ts
+++ b/artifacts/novel-reader/hooks/useDirectScraper.ts
@@ -551,9 +551,19 @@ export const directFetchNovelMeta = async (url: string): Promise<NovelMeta> => {
   console.log("[Scraper] Fetching novel meta from:", url);
 
   try {
-    const domainLower = url.toLowerCase();
-    const isLightNovelWorld = domainLower.includes("lightnovelworld");
-    const isAsianovel = domainLower.includes("asianovel.net");
+    let hostnameLower = "";
+    try {
+      hostnameLower = new URL(url).hostname.toLowerCase();
+    } catch {
+      hostnameLower = "";
+    }
+
+    const isLightNovelWorld =
+      hostnameLower === "lightnovelworld.com" ||
+      hostnameLower.endsWith(".lightnovelworld.com");
+    const isAsianovel =
+      hostnameLower === "asianovel.net" ||
+      hostnameLower.endsWith(".asianovel.net");
 
     const html = await fetchWithFallback(url, isAsianovel);
 


### PR DESCRIPTION
Potential fix for [https://github.com/Moggle-Khraum/NovelDR/security/code-scanning/59](https://github.com/Moggle-Khraum/NovelDR/security/code-scanning/59)

Use URL parsing and hostname-based validation instead of substring matching on the full URL string.

Best fix in this file:
- In `artifacts/novel-reader/hooks/useDirectScraper.ts`, inside `directFetchNovelMeta` (around current lines 554–557), replace:
  - `const domainLower = url.toLowerCase();`
  - `const isLightNovelWorld = domainLower.includes("lightnovelworld");`
  - `const isAsianovel = domainLower.includes("asianovel.net");`
- With logic that:
  1. Parses `url` using the built-in `URL` constructor.
  2. Extracts `hostname` in lowercase.
  3. Matches allowed domains using exact or `.${domain}` suffix checks.
  4. Gracefully handles invalid URLs (keep flags false).

No new dependency is required; `URL` is built into JS/TS runtime environments.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
