### PR TITLE
Potential fix for code scanning alert no. 53: Incomplete URL substring sanitization

### DIFF
--- a/artifacts/novel-reader/hooks/scrapers/sources/allnovel.ts
+++ b/artifacts/novel-reader/hooks/scrapers/sources/allnovel.ts
@@ -52,7 +52,8 @@ export const allNovelScraper: SourceScraper = {
   name: "AllNovel",
   canHandle: (url: string) => {
     try {
-      return new URL(url).hostname.includes(BASE_HOST);
+      const hostname = new URL(url).hostname.toLowerCase();
+      return hostname === BASE_HOST || hostname.endsWith(`.${BASE_HOST}`);
     } catch {
       return false;
     }


### PR DESCRIPTION
Potential fix for [https://github.com/Moggle-Khraum/NovelDR/security/code-scanning/53](https://github.com/Moggle-Khraum/NovelDR/security/code-scanning/53)

To fix this safely without changing intended functionality, parse the URL as already done, normalize the hostname, and only allow:

1. exact host match: `allnovel.org`
2. valid subdomains: `*.allnovel.org` (domain boundary check)

The best single change is inside `canHandle` in `artifacts/novel-reader/hooks/scrapers/sources/allnovel.ts` (around line 55): replace `hostname.includes(BASE_HOST)` with:

- `const hostname = new URL(url).hostname.toLowerCase();`
- `return hostname === BASE_HOST || hostname.endsWith(\`.${BASE_HOST}\`);`

This prevents substring bypasses while still accepting legitimate subdomains.

No new imports, helper methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
